### PR TITLE
Fixes Bower unable to find temporary hammer.js fork

### DIFF
--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -6,7 +6,7 @@ module.exports = {
 
   afterInstall: function() {
     var bowerPackages = [
-      { name: 'runspired/hammer.js', target: 'develop' },
+      { name: 'hammer.js', source: 'git@github.com:runspired/hammer.js.git', target: 'develop' },
       { name: 'hammer-time', target: '0.2.2'}
     ];
     return this.addBowerPackagesToProject(bowerPackages);

--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -7,7 +7,7 @@ module.exports = {
   afterInstall: function() {
     var bowerPackages = [
       { name: 'hammer.js', source: 'git@github.com:runspired/hammer.js.git', target: 'develop' },
-      { name: 'hammer-time', target: '0.2.2'}
+      { name: 'hammer-time', source: 'git@github.com:hammerjs/hammer-time.git', target: 'master' }
     ];
     return this.addBowerPackagesToProject(bowerPackages);
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   included : function (app) {
     app.import(app.bowerDirectory + '/hammerjs/hammer.min.js');
-    // app.import(app.bowerDirectory + '/hammer-time/hammer-time.js');
+    app.import(app.bowerDirectory + '/hammer-time/hammer-time.js');
   },
 
   isDevelopingAddon: function() {


### PR DESCRIPTION
Prevents `Package runspired/hammer.js=runspired/hammer.js not found` when trying to install with
Ember CLI `1.13.8`, Bower `1.5.2`