### PR TITLE
chore(build): only use minified hammerjs in production to make debugging easier

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,11 @@ module.exports = {
 
   included: function (app) {
     app.import('vendor/ember-gestures/dom-guard-begin.js');
-    app.import(app.bowerDirectory + '/hammerjs/hammer.min.js');
+    if (app.env === "production") {
+      app.import(app.bowerDirectory + '/hammerjs/hammer.min.js');
+    } else {
+      app.import(app.bowerDirectory + '/hammerjs/hammer.js');
+    }
     app.import(app.bowerDirectory + '/hammer-time/hammer-time.js');
     app.import('vendor/ember-gestures/dom-guard-end.js');
   },


### PR DESCRIPTION
Now the production will use hammer.min.js in production, otherwise use hammer.js. For some reason the sourcemap for the minified version was not working with Chrome to trace into hammerjs from an ember app using ember-gestures.