### PR TITLE
fix(service): avoid infinite recursion by registering recognizer before includes/excludes.

### DIFF
--- a/addon/services/-gestures.js
+++ b/addon/services/-gestures.js
@@ -31,6 +31,7 @@ export default Service.extend({
     options.event = eventName;
 
     let Recognizer = new Hammer[gesture](options);
+    this.registerRecognizer(name, Recognizer);
 
     if (details.include) {
       let included = details.include.map((name) => {
@@ -54,7 +55,6 @@ export default Service.extend({
 
     }
 
-    this.registerRecognizer(name, Recognizer);
     return Recognizer;
 
   },


### PR DESCRIPTION
Before this fix, it was possible to enter an infinite recursion whereby a recognizer is created over and over ad infinitum because it's not put into the cache immediately upon creation. This was because the recognizer could be created again when creating the included or excluded recognizers. This is avoided by putting the recognizer into the cache immediately, and thus the cached version is retrieved if one of the included or excluded ones depends on the one being created.