### PR TITLE
fix(lint): out of the box, generated recognizer doesn't pass linting …

### DIFF
--- a/blueprints/recognizer/files/__root__/ember-gestures/__path__/__name__.js
+++ b/blueprints/recognizer/files/__root__/ember-gestures/__path__/__name__.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
 export default {
   include: ['tap'], //an array of recognizers to recognize with.
   exclude: [], //an array of recognizers that must first fail


### PR DESCRIPTION
…with unused Ember imported.

Not sure how much you care about blueprint-generated files passing linting... but this fixes a failure, but if `Ember` is really generally needed in recognizers, then perhaps not importing it is a minor inconvenience.