### PR TITLE
test(recognizers): demo for a component with both single-tap and double-tap

### DIFF
--- a/tests/dummy/app/components/recognizes-single-and-double-tap.js
+++ b/tests/dummy/app/components/recognizes-single-and-double-tap.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import layout from '../templates/components/recognizes-single-and-double-tap';
+import RecognizerMixin from 'ember-gestures/mixins/recognizers';
+
+export default Ember.Component.extend(RecognizerMixin, {
+  layout: layout,
+  recognizers: 'single-tap double-tap',
+  sawSingle: false,
+  sawDouble: false,
+  singleTap: function() {
+    this.reset();
+    this.set('sawSingle', true);
+  },
+  doubleTap: function() {
+    this.reset();
+    this.set('sawDouble', true);
+  },
+  reset: function() {
+    this.set('sawSingle', false);
+    this.set('sawDouble', false);
+  }
+});

--- a/tests/dummy/app/ember-gestures/recognizers/double-tap.js
+++ b/tests/dummy/app/ember-gestures/recognizers/double-tap.js
@@ -1,0 +1,10 @@
+export default {
+  include: [], //an array of recognizers to recognize with.
+  exclude: [], //an array of recognizers that must first fail
+  options: {
+    event: 'doubletap',
+    taps: 2  // the settings to pass to the recognizer, event will be added automatically
+  },
+  includeEvents: true,
+  recognizer: 'tap' // `tap|press|pan|swipe|rotate|pinch` the base Hammer recognizer to use
+};

--- a/tests/dummy/app/ember-gestures/recognizers/single-tap.js
+++ b/tests/dummy/app/ember-gestures/recognizers/single-tap.js
@@ -1,0 +1,10 @@
+export default {
+  include: [], //an array of recognizers to recognize with.
+  exclude: ['double-tap'], //an array of recognizers that must first fail
+  options: {
+    event: 'singletap',
+    taps: 1  // the settings to pass to the recognizer, event will be added automatically
+  },
+  includeEvents: true,
+  recognizer: 'tap' // `tap|press|pan|swipe|rotate|pinch` the base Hammer recognizer to use
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('taps');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/taps.js
+++ b/tests/dummy/app/routes/taps.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -108,3 +108,7 @@ section.container-fluid {
   border: 1px solid #e8e8e8;
   border-radius: 2px;
 }
+
+.application-template {
+  margin: 2px 8px 10px 8px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,4 @@
-{{outlet}}
-
+<div class='application-template'>
+  <h1>ember-gestures dummy app</h1>
+  {{outlet}}
+</div>

--- a/tests/dummy/app/templates/components/recognizes-single-and-double-tap.hbs
+++ b/tests/dummy/app/templates/components/recognizes-single-and-double-tap.hbs
@@ -1,0 +1,9 @@
+Tap on me once or twice.
+
+{{#if sawSingle}}
+I saw a single-tap.
+{{/if}}
+
+{{#if sawDouble}}
+I saw a double-tap.
+{{/if}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,4 @@
+<h2>Demos index</h2>
+<ol>
+  <li>{{#link-to "taps"}}taps{{/link-to}}</li>
+</ol>

--- a/tests/dummy/app/templates/taps.hbs
+++ b/tests/dummy/app/templates/taps.hbs
@@ -1,0 +1,6 @@
+<div>{{#link-to "index"}}back to index{{/link-to}}</div>
+
+<h2>Taps tests</h2>
+{{recognizes-single-and-double-tap}}
+
+{{outlet}}


### PR DESCRIPTION
Single demo for the case when a component wants to recognize a `single-tap` and a `double-tap` in a mutually exclusive way. This works with the `STATE_LIMBO` hack to `hammer.js`, but if there's a way to get it to work with only changes to `ember-gestures` that may be preferable.