### PR TITLE
bugfix: add inline touch manipulation styles to link-to components

### DIFF
--- a/addon/components/component.js
+++ b/addon/components/component.js
@@ -5,4 +5,4 @@ const {
   Component
 } = Ember;
 
-export default Component.reopenClass(TouchActionMixin);
+export default Component.reopen(TouchActionMixin);

--- a/addon/components/link-component.js
+++ b/addon/components/link-component.js
@@ -1,6 +1,0 @@
-import Ember from 'ember';
-import TouchActionMixin from '../mixins/touch-action';
-
-let LinkComponent = Ember.LinkComponent || Ember.LinkView;
-
-export default LinkComponent.reopenClass(TouchActionMixin);

--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -13,6 +13,9 @@ const {
 export default Mixin.create({
   attributeBindings: ['touchActionStyle:style'],
   touchActionStyle: computed(function () {
-    return new SafeString(this.click ? 'touch-action: manipulation; -ms-touch-action: manipulation;' : '');
+    // TODO: handle this similarily to how the touch-action htmlbars ast transformer
+    // handles things - aka - sometimes we don't want to add this class, see
+    // ember-gestures/htmlbars-plugins/touch-action.js for those caveats
+    return new SafeString('touch-action: manipulation; -ms-touch-action: manipulation;');
   })
 });

--- a/app/initializers/ember-gestures.js
+++ b/app/initializers/ember-gestures.js
@@ -1,5 +1,4 @@
 // activate touch action css
-import LinkComponent from 'ember-gestures/components/link-component'; // jshint ignore:line
 import Component from 'ember-gestures/components/component'; // jshint ignore:line
 
 export default {

--- a/htmlbars-plugins/touch-action.js
+++ b/htmlbars-plugins/touch-action.js
@@ -11,7 +11,7 @@
  <HTMLElement {{action "foo"}} style="touch-action: manipulation; -ms-touch-action: manipulation;">
  ```
  */
-var TOUCH_ACTION = 'touch-action: manipulation; -ms-touch-action: manipulation';
+var TOUCH_ACTION = 'touch-action: manipulation; -ms-touch-action: manipulation;';
 
 function TouchActionSupport() {
   this.syntax = null;

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -7,6 +7,14 @@ test('visiting /index, ensures we hooked everything up appropriately', function(
   visit('/');
 
   andThen(function() {
+    let manualLink = find('li a:contains(A manual link)');
+    let expectedStyleManualLink = manualLink[0].attributes.style.value;
+    assert.equal(expectedStyleManualLink, 'touch-action: manipulation; -ms-touch-action: manipulation;');
+
+    let generatedLink = find('li a:contains(A generated link)');
+    let expectedGeneratedLink = generatedLink[0].attributes.style.value;
+    assert.equal(expectedGeneratedLink, 'touch-action: manipulation; -ms-touch-action: manipulation;');
+
     assert.equal(currentURL(), '/');
   });
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,4 +1,11 @@
 <h2>Demos index</h2>
+
+<h4>General Links to Homepage</h4>
 <ol>
-  <li>{{#link-to "taps"}}taps{{/link-to}}</li>
+  <li><a href="/">A manual link with touch support</a></li>
+  <li>{{#link-to 'application'}}A generated link with touch support{{/link-to}}</li>
+</ol>
+
+<ol>
+  <li>{{link-to 'tap' 'taps'}}</li>
 </ol>


### PR DESCRIPTION
- remove the link component as link component inherits from component
- add a semi-colon to the end of the ast transformer inline style
- dont handle logic for dealing when or when not to add styles to a
  component, as we do in the ast transformer. for now just always add the
  touch manipulation inline styles
- remove code duplication
- write regression test