### PR TITLE
fix(deprecations) Use getOwner polyfill for lookup*s

### DIFF
--- a/addon/event_dispatcher.js
+++ b/addon/event_dispatcher.js
@@ -3,6 +3,7 @@ import defaultHammerEvents from './hammer-events';
 import dasherizedToCamel from 'ember-allpurpose/string/dasherized-to-camel';
 import jQuery from 'jquery';
 import mobileDetection from './utils/is-mobile';
+import getOwner from 'ember-getowner-polyfill';
 
 let ROOT_ELEMENT_CLASS = 'ember-application';
 let ROOT_ELEMENT_SELECTOR = '.' + ROOT_ELEMENT_CLASS;
@@ -47,7 +48,7 @@ export default EventDispatcher.extend({
     const events = assign({}, defaultHammerEvents);
 
     list.forEach((name) => {
-      const recognizer = this.container.lookupFactory('ember-gesture:recognizers/' + name);
+      const recognizer = getOwner(this)._lookupFactory('ember-gesture:recognizers/' + name);
 
       if (recognizer) {
         addEvent(events, recognizer.recognizer, recognizer.eventName || name);

--- a/addon/services/-gestures.js
+++ b/addon/services/-gestures.js
@@ -2,6 +2,7 @@
 import Ember from 'ember';
 import camelize from 'ember-allpurpose/string/dasherized-to-camel';
 import capitalize from 'ember-allpurpose/string/capitalize-word';
+import getOwner from 'ember-getowner-polyfill';
 
 const {
   Service,
@@ -82,7 +83,7 @@ export default Service.extend({
     }
 
     const path = `ember-gesture:recognizers/${name}`;
-    const details = this.container.lookupFactory(path);
+    const details = getOwner(this)._lookupFactory(path);
 
     if (details) {
       return this.setupRecognizer(name, details);
@@ -101,7 +102,7 @@ export default Service.extend({
     }
 
     const path = `ember-gesture:recognizers/${name}`;
-    const details = this.container.lookupFactory(path);
+    const details = getOwner(this)._lookupFactory(path);
 
     if (details) {
       return this.setupRecognizer(name, details);

--- a/app/instance-initializers/ember-gestures.js
+++ b/app/instance-initializers/ember-gestures.js
@@ -1,3 +1,5 @@
+import getOwner from 'ember-getowner-polyfill';
+
 export default {
   name: 'ember-gestures',
 
@@ -6,7 +8,7 @@ export default {
       instance.lookup('service:-gestures');
     } else {
       // This can be removed when we no-longer support ember 1.12 and 1.13
-      instance.container.lookup('service:-gestures');
+      getOwner(instance).lookup('service:-gestures');
     }
   }
 

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "ember-load-initializers": "~0.1.7",
     "ember-qunit": "~0.4.18",
     "ember-qunit-notifications": "~0.1.0",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "~3.5.0",
     "qunit": "~1.20.0",
     "marked": "~0.3.5"


### PR DESCRIPTION
Running on 2.3 throws a bunch of deprecation warnings.

Unsure what happened to the changes in https://github.com/runspired/ember-gestures/commit/cb4570eb67f0291b4bc5c22850cef4dcdf4551d2 where the polyfill addon was added and some of the lookup calls were changed?