### PR TITLE
make swipe recognizer horizontal only

### DIFF
--- a/addon/recognizers/swipe.js
+++ b/addon/recognizers/swipe.js
@@ -1,6 +1,6 @@
 export default {
   include: [],
   exclude: [],
-  options: { threshold: 25 },
+  options: { threshold: 25, direction: Hammer.DIRECTION_HORIZONTAL },
   recognizer: 'swipe'
 };


### PR DESCRIPTION
It makes swipe recognizer horizontal only. It fixed this issue for me: https://github.com/runspired/ember-gestures/issues/32#issuecomment-173981062. But I'm not sure if it's a correct way to do it :/