### PR TITLE
Upon failing to find a recognizer reject the promise with a real Error object

### DIFF
--- a/addon/services/-gestures.js
+++ b/addon/services/-gestures.js
@@ -88,7 +88,7 @@ export default Service.extend({
       return this.setupRecognizer(name, details);
     }
 
-    return Promise.reject(`ember-gestures/recognizers/${name} was not found. You can scaffold this recognizer with 'ember g recognizer ${name}'`);
+    return Promise.reject(new Error(`ember-gestures/recognizers/${name} was not found. You can scaffold this recognizer with 'ember g recognizer ${name}'`));
 
   },
 
@@ -107,7 +107,7 @@ export default Service.extend({
       return this.setupRecognizer(name, details);
     }
 
-    return Promise.reject(`ember-gestures/recognizers/${name} was not found. You can scaffold this recognizer with 'ember g recognizer ${name}'`);
+    return Promise.reject(new Error(`ember-gestures/recognizers/${name} was not found. You can scaffold this recognizer with 'ember g recognizer ${name}'`));
   },
 
   init() {


### PR DESCRIPTION
When the gestures service is not able to find a recognizer, it returns a rejected promise with a string literal as the error value. As Ember.js (tested with 2.3.0) is expecting a real Error object and is trying to dump `error.stack` to the console (see https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/ext/rsvp.js#L72), you just get an `undefined` on the console without any message or clue where the error comes from.

This PR fixes it by creating an Error object, giving you the message and the stack trace on the console.