### PR TITLE
Add ember-getowner-polyfill as consuming app dep for Ember >= 2.3

### DIFF
--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -1,4 +1,5 @@
 var RSVP = require('rsvp');
+var VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
 
@@ -10,9 +11,16 @@ module.exports = {
     var bowerPackages = [
       { name: 'hammer.js', target: '2.0.6' }
     ];
+    var addonPackages = [
+      {name: 'ember-hammertime', target: '1.0.0'}
+    ];
+    var checker = new VersionChecker(this);
+    if (checker.for('ember', 'bower').satisfies('>= 2.3')) {
+      addonPackages.push({name: 'ember-getowner-polyfill', target: '^1.0.0'});
+    }
     return RSVP.all([
       this.addBowerPackagesToProject(bowerPackages),
-      this.addAddonToProject('ember-hammertime', '1.0.0')
+      this.addAddonsToProject({ packages: addonPackages })
     ]);
   }
 

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     "ember-cli-sri": "^1.2.1",
     "ember-cli-toolbelts": "0.2.5",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-version-checker": "^1.1.6",
     "ember-disable-prototype-extensions": "^1.0.1",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
+    "ember-getowner-polyfill": "^1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.0.8",
     "ember-velocity-mixin": "0.3.0"
@@ -59,7 +61,6 @@
     "ember-allpurpose": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-getowner-polyfill": "1.0.0",
     "rsvp": "^3.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This is a working fix for #39. Installation of this addon is still not smooth, even after #44 is merged. There is some confusion over what belongs as

* a npm dependency
* a npm devDependency
* a consuming app npm dependency
* a consuming app npm devDependency

I'll reach out to other members of the ember-cli team to see if we can organize some better documentation around this.