### PR TITLE
Work around race condition with concurrent bower installs

### DIFF
--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -8,6 +8,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
+    var addon = this;
     var bowerPackages = [
       { name: 'hammer.js', target: '2.0.6' }
     ];
@@ -20,10 +21,8 @@ module.exports = {
       addonPackages.push({name: 'ember-getowner-polyfill', target: '^1.0.0'});
     }
 
-    return RSVP.all([
-      this.addBowerPackagesToProject(bowerPackages),
-      this.addAddonsToProject({ packages: addonPackages })
-    ]);
+    return addon.addBowerPackagesToProject(bowerPackages).then(function() {
+      return addon.addAddonsToProject({ packages: addonPackages });
+    });
   }
-
 };

--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -1,4 +1,3 @@
-var RSVP = require('rsvp');
 var VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
@@ -13,10 +12,10 @@ module.exports = {
       { name: 'hammer.js', target: '2.0.6' }
     ];
     var addonPackages = [
-      {name: 'ember-hammertime', target: '1.0.0'}
+      { name: 'ember-hammertime', target: '1.0.0' }
     ];
 
-    var checker = new VersionChecker(this);
+    var checker = new VersionChecker(addon);
     if (checker.for('ember', 'bower').satisfies('>= 2.3')) {
       addonPackages.push({name: 'ember-getowner-polyfill', target: '^1.0.0'});
     }


### PR DESCRIPTION
This works around https://github.com/ember-cli/ember-cli/issues/5765

The issue is there are concurrent bower installs and the second starts before the first one settles (writes the update to bower.json).  So when the second install happens it uses the previous read bower.json to append to, writing over the initial entry since it wasn't there when it read `bower.json` into memory.

https://github.com/bower/bower/blob/343e6ac8bcb3ad69a90b2e8c37bf71796417f7b8/lib/core/Project.js#L44 `analyse` here reads bower.json and sets `that._json`

https://github.com/bower/bower/blob/343e6ac8bcb3ad69a90b2e8c37bf71796417f7b8/lib/core/Project.js#L111 writes `that._json` which doesn't contain the content of the first bower install

```
* read
* read (stale)
* write
* write
```

Where it should:

```
* read
* read
* re-read/write
* re-read/write
```

/cc @EricWalklet since you had issues setting up ember-gestures awhile back.  This was the cause