### PR TITLE
chore(deps) move ember-cli-version-checker to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "liquid-fire": "0.23.0",
     "loader.js": "^4.0.1",
     "ember-cli-content-security-policy": "^0.4.0",
-    "ember-cli-version-checker": "^1.1.6",
     "ember-getowner-polyfill": "^1.0.0",
     "ember-velocity-mixin": "0.3.0"
   },
@@ -66,6 +65,7 @@
     "pointer events"
   ],
   "dependencies": {
+    "ember-cli-version-checker": "^1.1.6",
     "ember-allpurpose": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",


### PR DESCRIPTION
Unable to run `ember install ember-cli-version-checker` without this change

It gives me the following error:
``` bash
Installed packages for tooling via npm.
Cannot find module 'ember-cli-version-checker'
Error: Cannot find module 'ember-cli-version-checker'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
```