### PR TITLE
Clean nasty Ember.merge deprecations

### DIFF
--- a/app/event_dispatcher.js
+++ b/app/event_dispatcher.js
@@ -2,12 +2,14 @@ import Ember from 'ember';
 import EventDispatcher from 'ember-gestures/event_dispatcher';
 import config from './config/environment';
 
-let gestures = Ember.merge({}, {
+const merge = Ember.assign || Ember.merge;
+
+let gestures = merge({}, {
     emberUseCapture: false,
     removeTracking: false,
     useFastPaths: false
   });
-gestures = Ember.merge(gestures, config.gestures);
+gestures = merge(gestures, config.gestures);
 
 export default EventDispatcher.extend({
   useCapture: gestures.emberUseCapture,

--- a/app/services/-gestures.js
+++ b/app/services/-gestures.js
@@ -2,16 +2,7 @@ import Ember from 'ember';
 import config from '../config/environment';
 import Service from 'ember-gestures/services/-gestures';
 
-const {
-	isEmpty
-} = Ember;
-
-let merge;
-if (!isEmpty(Ember.assign)) {
-	merge = Ember.assign;
-} else {
-	merge = Ember.merge;
-}
+const merge = Ember.assign || Ember.merge;
 
 let gestures = merge({}, {
   useCapture: false

--- a/app/services/-gestures.js
+++ b/app/services/-gestures.js
@@ -2,10 +2,21 @@ import Ember from 'ember';
 import config from '../config/environment';
 import Service from 'ember-gestures/services/-gestures';
 
-let gestures = Ember.merge({}, {
+const {
+	isEmpty
+} = Ember;
+
+let merge;
+if (!isEmpty(Ember.assign)) {
+	merge = Ember.assign;
+} else {
+	merge = Ember.merge;
+}
+
+let gestures = merge({}, {
   useCapture: false
 });
-gestures = Ember.merge(gestures, config.gestures);
+gestures = merge(gestures, config.gestures);
 
 export default Service.extend({
   useCapture: gestures.useCapture

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,11 +2,13 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
+const merge = Ember.assign || Ember.merge;
+
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(() => {
     application = Application.create(attributes);


### PR DESCRIPTION
Ensures Ember.assign is used where available so no deprecations appear in ember > 2.5