### PR TITLE
fastboot-bug/recognizers: Don't setup recognizers in fastboot

### DIFF
--- a/addon/mixins/recognizers.js
+++ b/addon/mixins/recognizers.js
@@ -9,6 +9,7 @@ const {
 export default Mixin.create({
 
   '-gestures': inject.service('-gestures'),
+  fastboot: inject.service(),
 
   recognizers: null,
   managerOptions: null,
@@ -71,6 +72,7 @@ export default Mixin.create({
 
   init() {
     this._super();
+    if (this.get('fastboot.isFastBoot')) { return; }
 
     // setup recognizers
     let recognizers = this.get('recognizers');

--- a/addon/mixins/recognizers.js
+++ b/addon/mixins/recognizers.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 const {
   inject,
@@ -9,7 +10,6 @@ const {
 export default Mixin.create({
 
   '-gestures': inject.service('-gestures'),
-  fastboot: inject.service(),
 
   recognizers: null,
   managerOptions: null,
@@ -72,7 +72,7 @@ export default Mixin.create({
 
   init() {
     this._super();
-    if (this.get('fastboot.isFastBoot')) { return; }
+    if (getOwner(this).hasRegistration('service:fastboot') && getOwner(this).lookup('service:fastboot').get('isFastBoot')) { return; }
 
     // setup recognizers
     let recognizers = this.get('recognizers');

--- a/addon/mixins/recognizers.js
+++ b/addon/mixins/recognizers.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
-  computed,
   inject,
   Mixin,
   on
@@ -11,12 +9,6 @@ const {
 export default Mixin.create({
 
   '-gestures': inject.service('-gestures'),
-
-  __fastboot: computed(function() {
-    let owner = getOwner(this);
-
-    return owner.lookup('service:fastboot');
-  }),
 
   recognizers: null,
   managerOptions: null,
@@ -37,8 +29,6 @@ export default Mixin.create({
   },
 
   __setupRecognizers: on('didInsertElement', function() {
-    if (this.get('__fastboot.isFastBoot')) { return; }
-
     const promise = this.get('recognizers');
     if (promise) {
       promise.then((recognizers) => {

--- a/addon/recognizers/pan.js
+++ b/addon/recognizers/pan.js
@@ -1,6 +1,6 @@
 export default {
   include: [],
   exclude: [],
-  options: { direction: typeof Hammer === 'undefined' ? '' : Hammer.DIRECTION_HORIZONTAL },
+  options: { direction: Hammer.DIRECTION_HORIZONTAL },
   recognizer: 'pan'
 };

--- a/addon/recognizers/swipe.js
+++ b/addon/recognizers/swipe.js
@@ -1,6 +1,6 @@
 export default {
   include: [],
   exclude: [],
-  options: { threshold: 25, direction: typeof Hammer === 'undefined' ? '' : Hammer.DIRECTION_HORIZONTAL },
+  options: { threshold: 25, direction: Hammer.DIRECTION_HORIZONTAL },
   recognizer: 'swipe'
 };

--- a/addon/recognizers/vertical-pan.js
+++ b/addon/recognizers/vertical-pan.js
@@ -2,6 +2,6 @@ export default {
   include: [],
   exclude: [],
   eventName: 'pan',
-  options: { direction: typeof Hammer === 'undefined' ? '' : Hammer.DIRECTION_VERTICAL },
+  options: { direction: Hammer.DIRECTION_VERTICAL },
   recognizer: 'pan'
 };

--- a/addon/recognizers/vertical-swipe.js
+++ b/addon/recognizers/vertical-swipe.js
@@ -2,6 +2,6 @@ export default {
   include: [],
   exclude: [],
   eventName: 'swipe',
-  options: { threshold: 25, direction: typeof Hammer === 'undefined' ? '' : Hammer.DIRECTION_VERTICAL},
+  options: { threshold: 25, direction: Hammer.DIRECTION_VERTICAL },
   recognizer: 'swipe'
 };

--- a/addon/services/-gestures.js
+++ b/addon/services/-gestures.js
@@ -4,7 +4,6 @@ import capitalize from 'ember-allpurpose/string/capitalize-word';
 import getOwner from 'ember-getowner-polyfill';
 
 const {
-  computed,
   Service,
   RSVP
 } = Ember;
@@ -17,11 +16,6 @@ const {
 export default Service.extend({
 
   _recognizers: null,
-  _fastboot: computed(function() {
-    let owner = getOwner(this);
-
-    return owner.lookup('service:fastboot');
-  }),
 
   retrieve(names) {
     let promises = names.map((name) => { return this.lookupRecognizer(name); });
@@ -44,7 +38,6 @@ export default Service.extend({
   },
 
   setupRecognizer(name, details) {
-    if (this.get('_fastboot.isFastBoot')) { return; }
     return Promise.resolve(this.createRecognizer(name, details))
 
       // includes


### PR DESCRIPTION
/cc @anthonybalmeo 

Try this out let me know if it works. The other option, to remove ember-gestures at build time (for fastboot only) is actually not possible b/c the recognizer mixin is already 'mixed' into the users app, thus the coupling there cannot be reversed at build time, bummer. 

**What this does**:

This will prevent issues where Hammer is not available in the built in recognizers and do the same when users generate/create their own recognizers(which prevents a footgun for users that would otherwise be required to understand the underlying implementation details for why they must use a typeof check for Hammer in their own recognizers)

**Reasoning**: 

The user events that fire any code paths in ember-gestures should never be triggered in node, and thus here we are simply preventing the Hammer errors by not 'registering' the recognizer(s) when user components that mixin the `ember-gestures/mixins/recognizer` 'mixin' are parsed and thus instantiated(which 'registers' the recognizer file associated with the `recognizers: 'a b c'` k/v pair on the component). 

**Need someone to test it out**

I have not run this code, I just happened to see this and know enough to help out, but it's still speculation until someone tries it :) @anthonybalmeo - if this does not work drop me a stack trace and I'll fix it up, gratzi senior.

related to #56 

(fyi @tomdale - cause i know u just love more pings from github - but seriously - just so your aware of hackz for fastboot in user land addons that I once said I would help with, but got lost doing other things 👎 , but i know your keeping tabs 👍)